### PR TITLE
feat: add database dump generation

### DIFF
--- a/app/Console/Commands/GenerateDatabaseDump.php
+++ b/app/Console/Commands/GenerateDatabaseDump.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+use Symfony\Component\Process\Process;
+use Symfony\Component\Process\Exception\ProcessFailedException;
+
+class GenerateDatabaseDump extends Command
+{
+    protected $signature = 'db:dump {--overwrite : Overwrite existing dump file}';
+    protected $description = 'Generate a new database dump file from current database';
+
+    public function handle()
+    {
+        $this->info('Generating database dump...');
+
+        $connection = config('database.default');
+        $config = config("database.connections.{$connection}");
+        $dumpPath = database_path('dump/database_dump.sql');
+
+        // Check if dump file exists
+        if (File::exists($dumpPath) && !$this->option('overwrite')) {
+            if (!$this->confirm('Dump file already exists. Overwrite?', false)) {
+                $this->info('Operation cancelled.');
+                return 0;
+            }
+        }
+
+        if ($connection === 'pgsql') {
+            $this->generatePostgresqlDump($config, $dumpPath);
+        } elseif ($connection === 'mysql' || $connection === 'mariadb') {
+            $this->generateMysqlDump($config, $dumpPath);
+        } else {
+            $this->error("Unsupported database driver: {$connection}");
+            return 1;
+        }
+
+        $this->info('Database dump generated successfully!');
+        return 0;
+    }
+
+    protected function generatePostgresqlDump(array $config, string $dumpPath)
+    {
+        $command = [
+            'pg_dump',
+            '-h', $config['host'],
+            '-p', $config['port'],
+            '-U', $config['username'],
+            '-d', $config['database'],
+            '--clean',
+            '--create',
+            '--if-exists',
+            '-f', $dumpPath
+        ];
+
+        $env = ['PGPASSWORD' => $config['password']];
+        $this->executeDumpCommand($command, $env);
+    }
+
+    protected function generateMysqlDump(array $config, string $dumpPath)
+    {
+        $command = [
+            'mysqldump',
+            '-h', $config['host'],
+            '-P', $config['port'],
+            '-u', $config['username'],
+            '-p' . $config['password'],
+            '--routines',
+            '--triggers',
+            '--single-transaction',
+            $config['database']
+        ];
+
+        $this->executeDumpCommand($command, [], $dumpPath);
+    }
+
+    protected function executeDumpCommand(array $command, array $env = [], string $outputFile = null)
+    {
+        $this->info('Running: ' . implode(' ', array_slice($command, 0, -2)) . ' [credentials hidden]');
+
+        $process = new Process($command, null, $env);
+        $process->setTimeout(3600);
+
+        try {
+            if ($outputFile && strpos(implode(' ', $command), '-f') === false) {
+                // For MySQL, redirect output to file
+                $process->mustRun();
+                File::put($outputFile, $process->getOutput());
+            } else {
+                // For PostgreSQL, output is already directed to file via -f flag
+                $process->mustRun(function ($type, $buffer) {
+                    if (Process::ERR === $type) {
+                        $this->error($buffer);
+                    } else {
+                        $this->line($buffer);
+                    }
+                });
+            }
+        } catch (ProcessFailedException $e) {
+            $this->error('Failed to generate database dump.');
+            $this->error($e->getMessage());
+            throw $e;
+        }
+    }
+}

--- a/app/Console/Commands/SetupDatabase.php
+++ b/app/Console/Commands/SetupDatabase.php
@@ -15,7 +15,7 @@ class SetupDatabase extends Command
      *
      * @var string
      */
-    protected $signature = 'db:setup {--fresh : Drop all tables before importing}';
+    protected $signature = 'db:setup {--fresh : Drop all tables before importing} {--dump : Generate dump from current database before setup}';
 
     /**
      * The console command description.
@@ -42,6 +42,10 @@ class SetupDatabase extends Command
         } else {
             $this->error("Unsupported database driver: {$connection}");
             return 1;
+        }
+
+        if ($this->option('dump')) {
+            $this->call('db:dump', ['--overwrite' => true]);
         }
 
         $this->info('Database setup completed successfully!');

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -14,7 +14,8 @@ class Kernel extends ConsoleKernel
      * @var array
      */
     protected $commands = [
-        SetupDatabase::class,
+        Commands\SetupDatabase::class,
+        Commands\GenerateDatabaseDump::class,
     ];
 
     /**

--- a/database/dump/database_dump.sql
+++ b/database/dump/database_dump.sql
@@ -3,7 +3,7 @@
 --
 
 -- Dumped from database version 14.4
--- Dumped by pg_dump version 15.2
+-- Dumped by pg_dump version 14.4
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -16,28 +16,32 @@ SET xmloption = content;
 SET client_min_messages = warning;
 SET row_security = off;
 
+DROP DATABASE IF EXISTS ocid_be;
 --
--- Name: public; Type: SCHEMA; Schema: -; Owner: postgres
+-- Name: ocid_be; Type: DATABASE; Schema: -; Owner: postgres
 --
 
--- *not* creating schema, since initdb creates it
+CREATE DATABASE ocid_be WITH TEMPLATE = template0 ENCODING = 'UTF8' LOCALE = 'English_Philippines.1252';
 
 
-ALTER SCHEMA public OWNER TO postgres;
+ALTER DATABASE ocid_be OWNER TO postgres;
+
+\connect ocid_be
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET xmloption = content;
+SET client_min_messages = warning;
+SET row_security = off;
 
 SET default_tablespace = '';
 
 SET default_table_access_method = heap;
-
---
--- Name: Temp; Type: TABLE; Schema: public; Owner: postgres
---
-
-CREATE TABLE public."Temp" (
-);
-
-
-ALTER TABLE public."Temp" OWNER TO postgres;
 
 --
 -- Name: cache; Type: TABLE; Schema: public; Owner: postgres
@@ -293,14 +297,6 @@ ALTER TABLE ONLY public.users ALTER COLUMN id SET DEFAULT nextval('public.users_
 
 
 --
--- Data for Name: Temp; Type: TABLE DATA; Schema: public; Owner: postgres
---
-
-COPY public."Temp"  FROM stdin;
-\.
-
-
---
 -- Data for Name: cache; Type: TABLE DATA; Schema: public; Owner: postgres
 --
 
@@ -510,14 +506,6 @@ CREATE INDEX sessions_last_activity_index ON public.sessions USING btree (last_a
 --
 
 CREATE INDEX sessions_user_id_index ON public.sessions USING btree (user_id);
-
-
---
--- Name: SCHEMA public; Type: ACL; Schema: -; Owner: postgres
---
-
-REVOKE USAGE ON SCHEMA public FROM PUBLIC;
-GRANT ALL ON SCHEMA public TO PUBLIC;
 
 
 --


### PR DESCRIPTION
This pull request introduces a new command for generating database dumps, integrates it into the existing database setup workflow, and updates the database dump file. The most important changes include the addition of the `GenerateDatabaseDump` command, enhancements to the `SetupDatabase` command to support dump generation, and updates to the `database_dump.sql` file to reflect the new dump structure.

### New Database Dump Command:
* Added a new `GenerateDatabaseDump` command to generate database dump files for PostgreSQL and MySQL/MariaDB databases. The command supports an `--overwrite` option to replace existing dump files. (`app/Console/Commands/GenerateDatabaseDump.php`)

### Enhancements to Database Setup:
* Updated the `SetupDatabase` command to include an `--dump` option, which triggers the generation of a database dump before setting up the database. (`app/Console/Commands/SetupDatabase.php`) [[1]](diffhunk://#diff-0ca7d074bcd689227addcc74b0547df33436f9a4f2d30bebe6beda5519a010cfL18-R18) [[2]](diffhunk://#diff-0ca7d074bcd689227addcc74b0547df33436f9a4f2d30bebe6beda5519a010cfR47-R50)
* Registered the new `GenerateDatabaseDump` command in the `Kernel` class to make it available for execution. (`app/Console/Kernel.php`)

### Updates to Database Dump File:
* Updated the `database_dump.sql` file to reflect a new structure, including changes to the database name, owner, and additional SQL statements for creating and configuring the database. (`database/dump/database_dump.sql`) [[1]](diffhunk://#diff-13d4a5efbd97cc0c9d8fccb5d82a40a75b676dd85a9323f827a17918b0cdec72L6-R6) [[2]](diffhunk://#diff-13d4a5efbd97cc0c9d8fccb5d82a40a75b676dd85a9323f827a17918b0cdec72R19-R44) [[3]](diffhunk://#diff-13d4a5efbd97cc0c9d8fccb5d82a40a75b676dd85a9323f827a17918b0cdec72L295-L302) [[4]](diffhunk://#diff-13d4a5efbd97cc0c9d8fccb5d82a40a75b676dd85a9323f827a17918b0cdec72L515-L522)