### PR TITLE
feat: add resource controllers and routes for managing

### DIFF
--- a/app/Http/Controllers/CampusController.php
+++ b/app/Http/Controllers/CampusController.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Campus;
+use App\Http\Traits\ApiResponseTrait;
+use Illuminate\Http\Request;
+use Illuminate\Http\JsonResponse;
+
+class CampusController extends Controller
+{
+    use ApiResponseTrait;
+    /**
+     * Display a listing of the resource.
+     */
+    public function index(): JsonResponse
+    {
+        $campuses = Campus::with('colleges')->get();
+        return $this->successResponse($campuses, 'Campuses retrieved successfully');
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(Request $request): JsonResponse
+    {
+        $request->validate([
+            'name' => 'required|string|max:255',
+            'address' => 'required|string|max:500',
+        ]);
+
+        $campus = Campus::create($request->only(['name', 'address']));
+        return $this->successResponse($campus, 'Campus created successfully', 201);
+    }
+    /**
+     * Display the specified resource.
+     */
+    public function show(Campus $campus): JsonResponse
+    {
+        $campus->load('colleges.undergrads', 'colleges.graduates');
+        return $this->successResponse($campus, 'Campus retrieved successfully');
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request, Campus $campus): JsonResponse
+    {
+        $request->validate([
+            'name' => 'sometimes|string|max:255',
+            'address' => 'sometimes|string|max:500',
+        ]);
+
+        $campus->update($request->only(['name', 'address']));
+        return $this->successResponse($campus, 'Campus updated successfully');
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(Campus $campus): JsonResponse
+    {
+        $campus->delete();
+        return $this->successResponse(null, 'Campus deleted successfully');
+    }
+}

--- a/app/Http/Controllers/CollegeController.php
+++ b/app/Http/Controllers/CollegeController.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\College;
+use App\Http\Traits\ApiResponseTrait;
+use Illuminate\Http\Request;
+use Illuminate\Http\JsonResponse;
+
+class CollegeController extends Controller
+{
+    use ApiResponseTrait;
+    /**
+     * Display a listing of the resource.
+     */
+    public function index(): JsonResponse
+    {
+        $colleges = College::with('campus', 'undergrads', 'graduates')->get();
+        return $this->successResponse($colleges, 'Colleges retrieved successfully');
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(Request $request): JsonResponse
+    {
+        $request->validate([
+            'name' => 'required|string|max:255',
+            'campus_id' => 'required|exists:campuses,id',
+        ]);
+
+        $college = College::create($request->only(['name', 'campus_id']));
+        $college->load('campus');
+        return $this->successResponse($college, 'College created successfully', 201);
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(College $college): JsonResponse
+    {
+        $college->load('campus', 'undergrads', 'graduates');
+        return $this->successResponse($college, 'College retrieved successfully');
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request, College $college): JsonResponse
+    {
+        $request->validate([
+            'name' => 'sometimes|string|max:255',
+            'campus_id' => 'sometimes|exists:campuses,id',
+        ]);
+
+        $college->update($request->only(['name', 'campus_id']));
+        $college->load('campus');
+        return $this->successResponse($college, 'College updated successfully');
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(College $college): JsonResponse
+    {
+        $college->delete();
+        return $this->successResponse(null, 'College deleted successfully');
+    }
+}

--- a/app/Http/Controllers/CurriculumController.php
+++ b/app/Http/Controllers/CurriculumController.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Curriculum;
+use App\Http\Traits\ApiResponseTrait;
+use Illuminate\Http\Request;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Validation\ValidationException;
+use Illuminate\Support\Facades\Validator;
+
+class CurriculumController extends Controller
+{
+    use ApiResponseTrait;
+
+    /**
+     * Display a listing of the resource.
+     */
+    public function index(): JsonResponse
+    {
+        $curricula = Curriculum::with(['graduateProgram.college', 'undergradProgram.college'])->get();
+        return $this->successResponse($curricula, 'Curricula retrieved successfully');
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(Request $request): JsonResponse
+    {
+        $request->validate([
+            'image_url' => 'required|string|url',
+            'program_id' => 'required|integer',
+            'program_type' => 'required|in:graduate,undergrad',
+        ]);
+
+        $this->validateProgramExists($request->program_id, $request->program_type);
+
+        $curriculum = Curriculum::create($request->only(['image_url', 'program_id', 'program_type']));
+        return $this->successResponse($curriculum, 'Curriculum created successfully', 201);
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(Curriculum $curriculum): JsonResponse
+    {
+        $curriculum->load(['graduateProgram.college', 'undergradProgram.college']);
+        return $this->successResponse($curriculum, 'Curriculum retrieved successfully');
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request, Curriculum $curriculum): JsonResponse
+    {
+        $request->validate([
+            'image_url' => 'sometimes|string|url',
+            'program_id' => 'sometimes|integer',
+            'program_type' => 'sometimes|in:graduate,undergrad',
+        ]);
+
+        if ($request->has(['program_id', 'program_type'])) {
+            $this->validateProgramExists($request->program_id, $request->program_type);
+        }
+
+        $curriculum->update($request->only(['image_url', 'program_id', 'program_type']));
+        return $this->successResponse($curriculum, 'Curriculum updated successfully');
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(Curriculum $curriculum): JsonResponse
+    {
+        $curriculum->delete();
+        return $this->successResponse(null, 'Curriculum deleted successfully');
+    }
+
+    /**
+     * Validate that the program exists.
+     */
+    private function validateProgramExists($programId, $programType)
+    {
+        $model = $programType === 'graduate' ? \App\Models\Graduate::class : \App\Models\Undergrad::class;
+
+        if (!$model::find($programId)) {
+            $validator = Validator::make([], []);
+            $validator->errors()->add('program_id', 'The selected program does not exist.');
+
+            throw new ValidationException($validator);
+        }
+    }
+}

--- a/app/Http/Controllers/FormController.php
+++ b/app/Http/Controllers/FormController.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Form;
+use App\Http\Traits\ApiResponseTrait;
+use Illuminate\Http\Request;
+use Illuminate\Http\JsonResponse;
+
+class FormController extends Controller
+{
+    use ApiResponseTrait;
+
+    /**
+     * Display a listing of the resource.
+     */
+    public function index(): JsonResponse
+    {
+        $forms = Form::all();
+        return $this->successResponse($forms, 'Forms retrieved successfully');
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+
+    public function store(Request $request): JsonResponse
+    {
+        $request->validate([
+            'form_number' => 'required|string|max:255|unique:forms',
+            'title' => 'required|string|max:255',
+            'purpose' => 'required|string',
+            'link' => 'required|string|url',
+            'revision' => 'required|string|max:255',
+        ]);
+
+        $form = Form::create($request->only(['form_number', 'title', 'purpose', 'link', 'revision']));
+        return $this->successResponse($form, 'Form created successfully', 201);
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(Form $form): JsonResponse
+    {
+        return $this->successResponse($form, 'Form retrieved successfully');
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request, Form $form): JsonResponse
+    {
+        $request->validate([
+            'form_number' => 'sometimes|string|max:255|unique:forms,form_number,' . $form->id,
+            'title' => 'sometimes|string|max:255',
+            'purpose' => 'sometimes|string',
+            'link' => 'sometimes|string|url',
+            'revision' => 'sometimes|string|max:255',
+        ]);
+
+        $form->update($request->only(['form_number', 'title', 'purpose', 'link', 'revision']));
+        return $this->successResponse($form, 'Form updated successfully');
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(Form $form): JsonResponse
+    {
+        $form->delete();
+        return $this->successResponse(null, 'Form deleted successfully');
+    }
+}

--- a/app/Http/Controllers/GraduateController.php
+++ b/app/Http/Controllers/GraduateController.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Graduate;
+use App\Http\Traits\ApiResponseTrait;
+use Illuminate\Http\Request;
+use Illuminate\Http\JsonResponse;
+
+class GraduateController extends Controller
+{
+    use ApiResponseTrait;
+
+    /**
+     * Display a listing of the resource.
+     */
+    public function index(): JsonResponse
+    {
+        $graduates = Graduate::with('college.campus', 'curriculum', 'syllabus')->get();
+        return $this->successResponse($graduates, 'Graduate programs retrieved successfully');
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+
+    public function store(Request $request): JsonResponse
+    {
+        $request->validate([
+            'program_name' => 'required|string|max:255',
+            'college_id' => 'required|exists:colleges,id',
+        ]);
+
+        $graduate = Graduate::create($request->only(['program_name', 'college_id']));
+        $graduate->load('college.campus');
+        return $this->successResponse($graduate, 'Graduate program created successfully', 201);
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(Graduate $graduate): JsonResponse
+    {
+        $graduate->load('college.campus', 'curriculum', 'syllabus');
+        return $this->successResponse($graduate, 'Graduate program retrieved successfully');
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request, Graduate $graduate): JsonResponse
+    {
+        $request->validate([
+            'program_name' => 'sometimes|string|max:255',
+            'college_id' => 'sometimes|exists:colleges,id',
+        ]);
+
+        $graduate->update($request->only(['program_name', 'college_id']));
+        $graduate->load('college.campus');
+        return $this->successResponse($graduate, 'Graduate program updated successfully');
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(Graduate $graduate): JsonResponse
+    {
+        $graduate->delete();
+        return $this->successResponse(null, 'Graduate program deleted successfully');
+    }
+}

--- a/app/Http/Controllers/SyllabusController.php
+++ b/app/Http/Controllers/SyllabusController.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Syllabus;
+use App\Http\Traits\ApiResponseTrait;
+use Illuminate\Http\Request;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Validation\ValidationException;
+use Illuminate\Support\Facades\Validator;
+
+class SyllabusController extends Controller
+{
+    use ApiResponseTrait;
+
+    /**
+     * Display a listing of the resource.
+     */
+    public function index(): JsonResponse
+    {
+        $syllabi = Syllabus::with(['graduateProgram.college', 'undergradProgram.college'])->get();
+        return $this->successResponse($syllabi, 'Syllabi retrieved successfully');
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(Request $request): JsonResponse
+    {
+        $request->validate([
+            'image_url' => 'required|string|url',
+            'program_id' => 'required|integer',
+            'program_type' => 'required|in:graduate,undergrad',
+        ]);
+
+        // Validate that the program exists
+        $this->validateProgramExists($request->program_id, $request->program_type);
+
+        $syllabus = Syllabus::create($request->only(['image_url', 'program_id', 'program_type']));
+        return $this->successResponse($syllabus, 'Syllabus created successfully', 201);
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(Syllabus $syllabus): JsonResponse
+    {
+        $syllabus->load(['graduateProgram.college', 'undergradProgram.college']);
+        return $this->successResponse($syllabus, 'Syllabus retrieved successfully');
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request, Syllabus $syllabus): JsonResponse
+    {
+        $request->validate([
+            'image_url' => 'sometimes|string|url',
+            'program_id' => 'sometimes|integer',
+            'program_type' => 'sometimes|in:graduate,undergrad',
+        ]);
+
+        if ($request->has(['program_id', 'program_type'])) {
+            $this->validateProgramExists($request->program_id, $request->program_type);
+        }
+
+        $syllabus->update($request->only(['image_url', 'program_id', 'program_type']));
+        return $this->successResponse($syllabus, 'Syllabus updated successfully');
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(Syllabus $syllabus): JsonResponse
+    {
+        $syllabus->delete();
+        return $this->successResponse(null, 'Syllabus deleted successfully');
+    }
+
+    /**
+     * Validate that the program exists.
+     */
+    private function validateProgramExists($programId, $programType)
+    {
+        $model = $programType === 'graduate' ? \App\Models\Graduate::class : \App\Models\Undergrad::class;
+
+        if (!$model::find($programId)) {
+            $validator = Validator::make([], []);
+            $validator->errors()->add('program_id', 'The selected program does not exist.');
+
+            throw new ValidationException($validator);
+        }
+    }
+}

--- a/app/Http/Controllers/UndergradController.php
+++ b/app/Http/Controllers/UndergradController.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Undergrad;
+use App\Http\Traits\ApiResponseTrait;
+use Illuminate\Http\Request;
+use Illuminate\Http\JsonResponse;
+
+class UndergradController extends Controller
+{
+    use ApiResponseTrait;
+
+    /**
+     * Display a listing of the resource.
+     */
+    public function index(): JsonResponse
+    {
+        $undergrads = Undergrad::with('college.campus', 'curriculum', 'syllabus')->get();
+        return $this->successResponse($undergrads, 'Undergraduate programs retrieved successfully');
+    }
+
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(Request $request): JsonResponse
+    {
+        $request->validate([
+            'program_name' => 'required|string|max:255',
+            'college_id' => 'required|exists:colleges,id',
+        ]);
+
+        $undergrad = Undergrad::create($request->only(['program_name', 'college_id']));
+        $undergrad->load('college.campus');
+        return $this->successResponse($undergrad, 'Undergraduate program created successfully', 201);
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(Undergrad $undergrad): JsonResponse
+    {
+        $undergrad->load('college.campus', 'curriculum', 'syllabus');
+        return $this->successResponse($undergrad, 'Undergraduate program retrieved successfully');
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request, Undergrad $undergrad): JsonResponse
+    {
+        $request->validate([
+            'program_name' => 'sometimes|string|max:255',
+            'college_id' => 'sometimes|exists:colleges,id',
+        ]);
+
+        $undergrad->update($request->only(['program_name', 'college_id']));
+        $undergrad->load('college.campus');
+        return $this->successResponse($undergrad, 'Undergraduate program updated successfully');
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(Undergrad $undergrad): JsonResponse
+    {
+        $undergrad->delete();
+        return $this->successResponse(null, 'Undergraduate program deleted successfully');
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,7 +1,14 @@
 <?php
 
-use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\AuthController;
+use App\Http\Controllers\CampusController;
+use App\Http\Controllers\CollegeController;
+use App\Http\Controllers\GraduateController;
+use App\Http\Controllers\UndergradController;
+use App\Http\Controllers\CurriculumController;
+use App\Http\Controllers\SyllabusController;
+use App\Http\Controllers\FormController;
+use Illuminate\Support\Facades\Route;
 
 // Public routes
 Route::prefix('auth')->group(function () {
@@ -28,4 +35,13 @@ Route::middleware('auth:sanctum')->group(function () {
         Route::delete('/tokens/{tokenId}', [AuthController::class, 'revokeToken']);
         Route::get('/activities', [AuthController::class, 'getUserActivities']);
     });
+
+    // Resource routes for managing data
+    Route::apiResource('campuses', CampusController::class);
+    Route::apiResource('colleges', CollegeController::class);
+    Route::apiResource('graduates', GraduateController::class);
+    Route::apiResource('undergrads', UndergradController::class);
+    Route::apiResource('curricula', CurriculumController::class);
+    Route::apiResource('syllabi', SyllabusController::class);
+    Route::apiResource('forms', FormController::class);
 });


### PR DESCRIPTION
This pull request introduces new RESTful API controllers for managing various entities (`Campus`, `College`, `Curriculum`, `Form`, `Graduate`, `Syllabus`, and `Undergrad`) and updates the API routes to include resource routes for these controllers. Each controller provides standard CRUD operations with validation and relationships. The most important changes are grouped below:

### New API Controllers
* Added `CampusController` to manage campuses, including CRUD operations and relationships with colleges.
* Added `CollegeController` to manage colleges, including CRUD operations and relationships with campuses, undergraduates, and graduates.
* Added `CurriculumController` and `SyllabusController` to manage curricula and syllabi, respectively, with program type validation and relationships with graduate and undergraduate programs. [[1]](diffhunk://#diff-2d1eac3719dd770caf48904760cf048b2cf55a20eea32585029a91d0222b00ebR1-R93) [[2]](diffhunk://#diff-f781a970353e97206acc4c7b3ae0a390ac306c762c45b083a8bc3f44a6b040c6R1-R94)
* Added `GraduateController` and `UndergradController` to manage graduate and undergraduate programs, with relationships to colleges, campuses, curricula, and syllabi. [[1]](diffhunk://#diff-8b2e3a74657c78df69140e214f46f42bb92149f12d6e4501aa019810d7fde79cR1-R71) [[2]](diffhunk://#diff-1930090cf4a302ae920d7407a02f8ff2db15a27c147c1873eefd6a3605b06007R1-R71)
* Added `FormController` to manage forms with unique constraints and validation for form attributes.

### API Route Updates
* Registered resource routes for the new controllers in `routes/api.php`, enabling RESTful endpoints for managing campuses, colleges, graduates, undergrads, curricula, syllabi, and forms.
* Imported the new controllers in `routes/api.php` for route definitions.